### PR TITLE
Coerce config[:bin] from YAML to Array.

### DIFF
--- a/lib/genevalidatorapp.rb
+++ b/lib/genevalidatorapp.rb
@@ -178,7 +178,7 @@ module GeneValidatorApp
 
     def init_bins
       bins = []
-      config[:bin].each do |bin|
+      Array(config[:bin]).each do |bin|
         bins << File.expand_path(bin)
         unless File.exist?(bin) && File.directory?(bin)
           fail BIN_DIR_NOT_FOUND, config[:bin]


### PR DESCRIPTION
Avoids `undefined method`each' for "/some/path":String` if the user only has one bin dir to specify through YAML configuration file.
